### PR TITLE
Remove Fathom analytics

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -13,10 +13,6 @@ import {
   redirect,
 } from "react-router";
 import type { LoaderFunctionArgs } from "react-router";
-import {
-  load as loadFathom,
-  type LoadOptions as FathomLoadOptions,
-} from "fathom-client";
 import "~/styles/tailwind.css";
 import "~/styles/bailwind.css";
 import { removeTrailingSlashes, handleRedirects } from "~/lib/http.server";
@@ -158,15 +154,6 @@ export default function App() {
     return false;
   });
 
-  if (process.env.NODE_ENV !== "development") {
-    // oxlint-disable-next-line react-hooks/rules-of-hooks
-    useFathomClient("IRVDGCHK", {
-      url: "https://cdn.usefathom.com/script.js",
-      spa: "history",
-      excludedDomains: ["localhost"],
-    });
-  }
-
   return (
     <Document noIndex={noIndex} forceDark={forceDark}>
       <Outlet />
@@ -224,13 +211,4 @@ export function ErrorBoundary() {
       </div>
     </Document>
   );
-}
-
-function useFathomClient(siteId: string, loadOptions: FathomLoadOptions) {
-  let loaded = React.useRef(false);
-  React.useEffect(() => {
-    if (loaded.current) return;
-    loadFathom(siteId, loadOptions);
-    loaded.current = true;
-  }, [loadOptions, siteId]);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "clsx": "^2.1.1",
         "cssnano": "^6.0.3",
         "escape-goat": "^4.0.0",
-        "fathom-client": "^3.6.0",
         "front-matter": "^4.0.2",
         "gray-matter": "^4.0.3",
         "isbot": "^4",
@@ -4527,11 +4526,6 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
-    },
-    "node_modules/fathom-client": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/fathom-client/-/fathom-client-3.6.0.tgz",
-      "integrity": "sha512-/mrgmVvpw4HqDCcqUfPulERhONKgnJGL74RAxfqKDuRQ+7w9lKoTHMzqBWE7WNBvmsgZEthQWJFOWOEjv+T3gA=="
     },
     "node_modules/fill-range": {
       "version": "7.1.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "clsx": "^2.1.1",
     "cssnano": "^6.0.3",
     "escape-goat": "^4.0.0",
-    "fathom-client": "^3.6.0",
     "front-matter": "^4.0.2",
     "gray-matter": "^4.0.3",
     "isbot": "^4",


### PR DESCRIPTION
We don't need to track visits to old docs anymore.

- Removed fathom-client dependency from package.json
- Removed Fathom loading and useFathomClient hook from app/root.tsx